### PR TITLE
[refactor] 아파트 키워드 검색 리팩토링

### DIFF
--- a/back/homedatazip/src/main/java/org/example/homedatazip/apartment/dto/AptSaleAggregation.java
+++ b/back/homedatazip/src/main/java/org/example/homedatazip/apartment/dto/AptSaleAggregation.java
@@ -2,41 +2,17 @@ package org.example.homedatazip.apartment.dto;
 
 public record AptSaleAggregation(
         Long aptId,
-
-        // 6개월 집계
-        Long sixMonthAmountSum,
-        Long sixMonthSaleCount,
-
-        // 전전월 집계
-        Long twoMonthsAgoAmountSum,
-        Long twoMonthsAgoSaleCount,
+        Long areaTypeId,
 
         // 전월 집계
         Long lastMonthAmountSum,
-        Long lastMonthSaleCount
+        Long lastMonthSaleCount,
+
+        // 비교 대상월(과거 중 거래가 있는 최신 월)
+        String compareYyyymm,
+        Long compareMonthAmountSum,
+        Long compareMonthSaleCount
 ) {
-
-    /**
-     * 6개월 평균 거래가
-     */
-    public Long getSixMonthAvgAmount() {
-        if (sixMonthSaleCount == null || sixMonthSaleCount == 0) {
-            return null;
-        }
-
-        return sixMonthAmountSum / sixMonthSaleCount;
-    }
-
-    /**
-     * 전전월 평균 거래가
-     */
-    public Long getTwoMonthsAgoAvgAmount() {
-        if (twoMonthsAgoSaleCount == null || twoMonthsAgoSaleCount == 0) {
-            return null;
-        }
-
-        return twoMonthsAgoAmountSum / twoMonthsAgoSaleCount;
-    }
 
     /**
      * 전월 평균 거래가
@@ -50,19 +26,30 @@ public record AptSaleAggregation(
     }
 
     /**
+     * 비교 대상월 평균 거래가
+     */
+    public Long getCompareMonthAvgAmount() {
+        if (compareMonthSaleCount == null || compareMonthSaleCount == 0) {
+            return null;
+        }
+
+        return compareMonthAmountSum / compareMonthSaleCount;
+    }
+
+    /**
      * 등락률 계산
      * <br/>
      * (전월 평균 거래가 - 전전월 평균 거래가) / 전전월 평균 거래가 * 100
      */
     public Double getPriceChangeRate() {
         Long lastMonthAvg = getLastMonthAvgAmount();
-        Long twoMonthsAgoAvg = getTwoMonthsAgoAvgAmount();
+        Long compareMonthAvg = getCompareMonthAvgAmount();
 
-        if (lastMonthAvg == null || twoMonthsAgoAvg == null || twoMonthsAgoAvg == 0) {
+        if (lastMonthAvg == null || compareMonthAvg == null || compareMonthAvg == 0) {
             return null;
         }
 
-        return ((lastMonthAvg.doubleValue() - twoMonthsAgoAvg.doubleValue())
-                / twoMonthsAgoAvg.doubleValue()) * 100;
+        return ((lastMonthAvg.doubleValue() - compareMonthAvg.doubleValue())
+                / compareMonthAvg.doubleValue()) * 100;
     }
 }

--- a/back/homedatazip/src/main/java/org/example/homedatazip/apartment/dto/AptSummaryResponse.java
+++ b/back/homedatazip/src/main/java/org/example/homedatazip/apartment/dto/AptSummaryResponse.java
@@ -4,8 +4,9 @@ public record AptSummaryResponse(
         Long aptId, // 아파트 id
         String aptName, // 아파트 이름
         String gu, // 구
+        Long areaTypeId, // 평수 타입
         Long AvgDealAmount, // 평균 거래가
-        Double priceChangeRate, // 전월 대비 등략률
+        Double priceChangeRate, // 등략률
         Integer tradeCount // 거래량
 ) {
 }

--- a/back/homedatazip/src/main/java/org/example/homedatazip/apartment/repository/ApartmentSearchRepository.java
+++ b/back/homedatazip/src/main/java/org/example/homedatazip/apartment/repository/ApartmentSearchRepository.java
@@ -6,10 +6,13 @@ import java.util.List;
 
 public interface ApartmentSearchRepository {
 
+    /**
+     * 전월 집계 + 비교 대상월 집계 조회
+     * (아파트별, 평수별)
+     */
     List<AptSaleAggregation> findSaleAggregationByAptIds(
             List<Long> aptIds,
-            String sixMonthsAgo,
-            String twoMonthsAgo,
-            String lastMonth
+            String lastMonth,
+            String searchMonth
     );
 }


### PR DESCRIPTION
- (아파트 전체 6개월 기준 -> 평수별 전월 기준) 평균 거래가 및 거래량 노출로 변경
- 등락률 계산 시 전전월 거래가 없는 경우 가장 최신의 거래가 있는 월과 등락률 비교하도록 변경
- 거래량 많은 순 정렬